### PR TITLE
Closeup images in dialogue now automatically set themselves to native…

### DIFF
--- a/myth-office/Assets/03_Scripts/DialogueManager.cs
+++ b/myth-office/Assets/03_Scripts/DialogueManager.cs
@@ -181,6 +181,7 @@ public class DialogueManager : AbstractInteractable
             leftImage.sprite = response.leftImage;
             leftImage.preserveAspect = true;
             SetSpeakerImageRect(response.leftImage, leftImage);
+            leftImage.SetNativeSize();
 
             // Allow each image to have a custom pivot by reading pivots from the sprite data.
             leftImage.GetComponent<RectTransform>().pivot = leftImage.sprite.pivot / leftImage.sprite.texture.Size();
@@ -196,6 +197,7 @@ public class DialogueManager : AbstractInteractable
             rightImage.sprite = response.rightImage;
             rightImage.preserveAspect = true;
             SetSpeakerImageRect(response.rightImage, rightImage);
+            rightImage.SetNativeSize();
 
             // Allow each image to have a custom pivot by reading pivots from the sprite data.
             rightImage.GetComponent<RectTransform>().pivot = rightImage.sprite.pivot / rightImage.sprite.texture.Size();


### PR DESCRIPTION
… size

This makes the art workflow a lot easier and controllable, but doesn't look good with the old intern placeholder or odin because they're not exported for this format.